### PR TITLE
keeping type information, added test for typed groupByRelationalKey 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1735,15 +1735,14 @@ class Dataset[T] private[sql](
   @scala.annotation.varargs
   def groupByRelationKey(
       col1: String,
-      cols: String*): KeyValueGroupedDataset[Row, Row] = {
+      cols: String*): KeyValueGroupedDataset[Row, T] = {
     val colNames: Seq[String] = col1 +: cols
     val keyAttrs = colNames.map(colName => resolve(colName).toAttribute)
     val keySchema = StructType.fromAttributes(keyAttrs)
     val keyEncoder = RowEncoder(keySchema)
-    val valEncoder = RowEncoder(schema)
     new KeyValueGroupedDataset(
       keyEncoder,
-      valEncoder,
+      encoder,
       queryExecution,
       logicalPlan.output,
       keyAttrs)


### PR DESCRIPTION
I changed the `groupedByRelationalKey` method to keep the type information and added test to make sure that the type cogroup works.

Thanks again for your quick effort in response to my jira!