### PR TITLE
Upgrade to log4j 2.17

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -186,10 +186,10 @@ lapack/2.2.1//lapack-2.2.1.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.16.0//log4j-1.2-api-2.16.0.jar
-log4j-api/2.16.0//log4j-api-2.16.0.jar
-log4j-core/2.16.0//log4j-core-2.16.0.jar
-log4j-slf4j-impl/2.16.0//log4j-slf4j-impl-2.16.0.jar
+log4j-1.2-api/2.17.0//log4j-1.2-api-2.17.0.jar
+log4j-api/2.17.0//log4j-api-2.17.0.jar
+log4j-core/2.17.0//log4j-core-2.17.0.jar
+log4j-slf4j-impl/2.17.0//log4j-slf4j-impl-2.17.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 macro-compat_2.12/1.1.1//macro-compat_2.12-1.1.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -173,10 +173,10 @@ lapack/2.2.1//lapack-2.2.1.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.16.0//log4j-1.2-api-2.16.0.jar
-log4j-api/2.16.0//log4j-api-2.16.0.jar
-log4j-core/2.16.0//log4j-core-2.16.0.jar
-log4j-slf4j-impl/2.16.0//log4j-slf4j-impl-2.16.0.jar
+log4j-1.2-api/2.17.0//log4j-1.2-api-2.17.0.jar
+log4j-api/2.17.0//log4j-api-2.17.0.jar
+log4j-core/2.17.0//log4j-core-2.17.0.jar
+log4j-slf4j-impl/2.17.0//log4j-slf4j-impl-2.17.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 macro-compat_2.12/1.1.1//macro-compat_2.12-1.1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.30</slf4j.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.0</log4j.version>
     <hadoop.version>3.3.1</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>


### PR DESCRIPTION
After another issue has been found on log4j 2.16, this upgrades its
version to 2.17.
